### PR TITLE
lambda can be parameterless

### DIFF
--- a/PythonImproved.tmLanguage
+++ b/PythonImproved.tmLanguage
@@ -576,7 +576,7 @@
         </dict>
         <dict>
             <key>begin</key>
-            <string>(lambda)(?=\s+)</string>
+            <string>(lambda)(?=\s+|:)</string>
             <key>beginCaptures</key>
             <dict>
                 <key>1</key>


### PR DESCRIPTION
Fix 'str' highlighting for this code example

``` python
def f(k=lamda: 'str'):
    pass
```
