### PR TITLE
Highlight python byte strings

### DIFF
--- a/PythonImproved.json-tmLanguage
+++ b/PythonImproved.json-tmLanguage
@@ -304,13 +304,16 @@
                         {
                             "captures": {
                                 "1": {
-                                    "name": "variable.parameter.function.python"
+                                    "name": "variable.parameter.function.language.python"
                                 },
                                 "2": {
+                                    "name": "variable.parameter.function.python"
+                                },
+                                "3": {
                                     "name": "punctuation.separator.parameters.python"
                                 }
                             },
-                            "match": "\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)]))"
+                            "match": "\\b(?:(self|cls)|([a-zA-Z_][a-zA-Z_0-9]*))\\s*(?:(,)|(?=[\\n\\)]))"
                         }
                     ]
                 },

--- a/PythonImproved.tmLanguage
+++ b/PythonImproved.tmLanguage
@@ -473,16 +473,21 @@
                                 <key>1</key>
                                 <dict>
                                     <key>name</key>
-                                    <string>variable.parameter.function.python</string>
+                                    <string>variable.parameter.function.language.python</string>
                                 </dict>
                                 <key>2</key>
+                                <dict>
+                                    <key>name</key>
+                                    <string>variable.parameter.function.python</string>
+                                </dict>
+                                <key>3</key>
                                 <dict>
                                     <key>name</key>
                                     <string>punctuation.separator.parameters.python</string>
                                 </dict>
                             </dict>
                             <key>match</key>
-                            <string>\b([a-zA-Z_][a-zA-Z_0-9]*)\s*(?:(,)|(?=[\n\)]))</string>
+                            <string>\b(?:(self|cls)|([a-zA-Z_][a-zA-Z_0-9]*))\s*(?:(,)|(?=[\n\)]))</string>
                         </dict>
                     </array>
                 </dict>


### PR DESCRIPTION
Resolves the issue here:
    https://github.com/MattDMo/PythonImproved/issues/3

I also added a `json-tmLanguage`, the `tmLanguage` was getting a little too hard for me to understand!
