### PR TITLE
Don't highlight invalid partial binary literals

### DIFF
--- a/PythonImproved.YAML-tmLanguage
+++ b/PythonImproved.YAML-tmLanguage
@@ -40,10 +40,10 @@ patterns:
   match: \b(?i:(0x\h*))
 
 - name: constant.numeric.integer.long.binary.python
-  match: \b(?i:(0b[01]*)L)
+  match: \b(?i:(0b[01]+)L)
 
 - name: constant.numeric.integer.binary.python
-  match: \b(?i:(0b[01]*))
+  match: \b(?i:(0b[01]+))
 
 - name: constant.numeric.integer.long.octal.python
   match: \b(?i:(0[o]?[0-7]+)L)

--- a/PythonImproved.tmLanguage
+++ b/PythonImproved.tmLanguage
@@ -115,13 +115,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:(0b[01]*)L)</string>
+			<string>\b(?i:(0b[01]+)L)</string>
 			<key>name</key>
 			<string>constant.numeric.integer.long.binary.python</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:(0b[01]*))</string>
+			<string>\b(?i:(0b[01]+))</string>
 			<key>name</key>
 			<string>constant.numeric.integer.binary.python</string>
 		</dict>


### PR DESCRIPTION
Previous implementation would highlight binary literal fragments without any actual binary values in them (e.g. `0b`) which aren't valid. This patch fixes highlighting in an attempt to make invalid binary literal fragments easier to spot.